### PR TITLE
Add __name__ attr to post save hook partial for SingleUserNotebookApp

### DIFF
--- a/jupyterlab_autoversion/storage/git/__init__.py
+++ b/jupyterlab_autoversion/storage/git/__init__.py
@@ -37,5 +37,8 @@ def initialize(nb_server_app):
         (url_path_join(base_url, "autoversion/get"), GitGetHandler, context),
         (url_path_join(base_url, "autoversion/restore"), GitRestoreHandler, context),
     ]
-
-    return partial(post_save_autocommit_git, repo=repo), handlers
+   
+    post_save_autocommit_git_repo = partial(post_save_autocommit_git, repo)
+    post_save_autocommit_git_repo.__name__ = "post_save_autocommit_git_repo" 
+    
+    return post_save_autocommit_git_repo, handlers


### PR DESCRIPTION
Fixes this error that causes the extension not to load:

```
[W 2022-04-09 01:28:04.201 SingleUserNotebookApp manager:356] jupyterlab_autoversion.extension | extension failed loading with message: 'functools.partial' object has no attribute '__name__'
```

functools.partials are "__name__"-less which breaks initialization in SingleUserNotebookApp, which is used by Jupyterlab instances started under JupyterHub.

There are a couple of options for fixes (like using a closure instead of partial), but patching in a name attribute seems like the smallest change.