### PR TITLE
Fix Ruff lint violations

### DIFF
--- a/jupyterlab_autoversion/extension.py
+++ b/jupyterlab_autoversion/extension.py
@@ -15,7 +15,7 @@ def load_jupyter_server_extension(nb_server_app):
     backend = nb_server_app.config.get("JupyterLabAutoversion", {}).get("backend", "git")
 
     if backend not in ("git", "s3", "sql"):
-        raise Exception("jupyterlab_autoversion backend not recognized: {}".format(backend))
+        raise ValueError(f"jupyterlab_autoversion backend not recognized: {backend}")
 
     if backend == "s3":
         from .storage.s3 import initialize
@@ -26,7 +26,7 @@ def load_jupyter_server_extension(nb_server_app):
 
     hook, handlers = initialize(nb_server_app)
 
-    print("Installing jupyterlab_autoversion handler on path %s" % url_path_join(base_url, "autoversion"))
+    print(f"Installing jupyterlab_autoversion handler on path {url_path_join(base_url, 'autoversion')}")
 
     web_app.add_handlers(host_pattern, handlers)
     nb_server_app.contents_manager.register_pre_save_hook(hook)

--- a/jupyterlab_autoversion/storage/git/diff.py
+++ b/jupyterlab_autoversion/storage/git/diff.py
@@ -35,7 +35,7 @@ class GitDiffHandler(JupyterHandler):
             return
 
         # original head index
-        past = sorted(self.repo.tags, key=lambda t: t.commit.committed_datetime)[-1]
+        past = max(self.repo.tags, key=lambda t: t.commit.committed_datetime)
 
         # connect to git repo
         git = Git(self.repo.working_tree_dir)

--- a/jupyterlab_autoversion/storage/git/handlers.py
+++ b/jupyterlab_autoversion/storage/git/handlers.py
@@ -28,7 +28,7 @@ class GitGetHandler(JupyterHandler):
 
         last = [
             [x.commit.hexsha, x.commit.authored_date * 1000] + x.name.split("-")
-            for x in reversed(sorted(self.repo.tags, key=lambda t: t.commit.committed_datetime))
+            for x in sorted(self.repo.tags, key=lambda t: t.commit.committed_datetime, reverse=True)
             if id in x.name
         ]
 
@@ -62,7 +62,7 @@ class GitRestoreHandler(JupyterHandler):
             return
 
         # original head index
-        past = sorted(self.repo.tags, key=lambda t: t.commit.committed_datetime)[-1]
+        past = max(self.repo.tags, key=lambda t: t.commit.committed_datetime)
 
         # connect to git repo
         git = Git(self.repo.working_tree_dir)

--- a/jupyterlab_autoversion/storage/git/hook.py
+++ b/jupyterlab_autoversion/storage/git/hook.py
@@ -31,5 +31,5 @@ def post_save_autocommit_git(repo, model, *args, **kwargs):
         last = len([x for x in repo.tags if id in x.name])
 
         repo.index.add([nb])
-        repo.index.commit("%s-%d" % (id, last))
-        repo.create_tag("%s-%d" % (id, last))
+        repo.index.commit(f"{id}-{last}")
+        repo.create_tag(f"{id}-{last}")

--- a/jupyterlab_autoversion/storage/s3/__init__.py
+++ b/jupyterlab_autoversion/storage/s3/__init__.py
@@ -1,2 +1,2 @@
-from .handlers import *  # noqa: F401, F403
-from .hook import *  # noqa: F401, F403
+from .handlers import *
+from .hook import *

--- a/jupyterlab_autoversion/storage/sql/__init__.py
+++ b/jupyterlab_autoversion/storage/sql/__init__.py
@@ -1,2 +1,2 @@
-from .handlers import *  # noqa: F401, F403
-from .hook import *  # noqa: F401, F403
+from .handlers import *
+from .hook import *

--- a/jupyterlab_autoversion/tests/test_all.py
+++ b/jupyterlab_autoversion/tests/test_all.py
@@ -1,1 +1,1 @@
-from jupyterlab_autoversion import *  # noqa
+from jupyterlab_autoversion import *


### PR DESCRIPTION
## Description

Update Python code for newly enabled Ruff checks without changing lint rules. Changes use specific exceptions, modern string formatting and collection helpers, and remove obsolete `noqa` directives.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [ ] Tests pass (`make test`) — Python tests pass (`make test-py`)
- [ ] New tests added for new functionality — no functionality added
- [ ] Documentation updated (if applicable) — not applicable
- [ ] Changelog / version bump (if applicable) — not applicable